### PR TITLE
Fix image export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 #*#
 *~
 node_modules
+.idea/*

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ import interpret from './interpreter.js';
 
 import { commands } from './orderedCommands.js';
 import { colours, WHITE, BLACK } from './colours.js';
+import Jimp from "jimp";
 
 /* re-order commands to correspond to colours order based on currently-selected colour
  * NOTE: this was used to compute all command orders, which were saved to be re-used;
@@ -201,7 +202,13 @@ const appState = {
         image.resize(scale * appState.width, scale * appState.height, Jimp.RESIZE_NEAREST_NEIGHBOR);
 
         image.getBase64(Jimp.MIME_PNG, (_, uri) => {
-            window.open(uri);
+            fetch(uri)
+              .then(res => res.blob())
+              .then(blob => {
+                  const fileURL = URL.createObjectURL(blob);
+                  window.open(fileURL);
+              })
+
         });
     }).bind(this),
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "babel-polyfill": "^6.26.0",
     "babelify": "^7.3.0",
     "browserify": "^14.4.0",
+    "jimp": "^0.16.1",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "watchify": "^3.9.0"


### PR DESCRIPTION
Out of security reasons navigating to data urls is now disabled in browsers. Resolves #7

An alternative is opening a window with a [blob](https://stackoverflow.com/a/45700813/5504438) and to get the blob we [convert the base64 string to it](https://stackoverflow.com/a/36183085/5504438)

